### PR TITLE
Link fixes for README.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,27 @@ open-tamil provides Python package 'tamil' with ability to,
 1. map unicode code-points to Tamil letters - basic but important parsing - in a routine called get_letters from a Tamil word
    '''tamil.utf8.get_letters''' and '''tamil.utf8.get_letters_iterable''' API return the Tamil letters from the unicode points of a normalized unicode string.
    These routines are written with efficiency in mind, and tested for accuracy.
-   
+
 2. work with vowels (uyir) and consonants (mei), compound, uyir-mei letters
 3. reverse letters in Tamil word
 4. numeral - convert a given number (integer) into a numeral in Indian or American based system.
    e.g. following call will return the string
-        >> '''tamil.numeral.num2tamilstr_american( long(1e7) )'''  
+        >> '''tamil.numeral.num2tamilstr_american( long(1e7) )'''
         u"பத்து மில்லியன்",
 
 #txt2unicode
 Tamil Text Encode to Unicode Converter and vice versa.
-If you Don't you know what your Tamil text encoding, don't worry; the '''tamil.txt2unicode.auto2unicode''' function will find it and convert to unicode for you. 
+If you Don't you know what your Tamil text encoding, don't worry; the '''tamil.txt2unicode.auto2unicode''' function will find it and convert to unicode for you.
 யுனிகோட் மாற்றி மற்றும் மாறாகவும் தமிழ் உரை குறியாக்கம்.
 நீங்கள் என்ன உங்கள் தமிழ் உரை குறியீட்டு தெரியாது என்றால், கவலைப்பட வேண்டாம்; '' 'tamil.txt2unicode.auto2unicode' '' செயல்பாடு அது கண்டுபிடிக்கும் & நீங்கள் யுனிகோட் மாற்ற வேண்டும்.
 
 Right now, it supports with 25 Tamil encodes. Read more details about [txt2unicode](tamil/txt2unicode/README.md) and [limitation](examples/txt2unicode/encodes_chars/README.md) of `auto2unicode` and `unicode2auto`
-இப்போது, அது 25 தமிழ் குறியாக்கம் கொண்ட ஆதரிக்கிறது. 'auto2unicode' மற்றும் 'unicode2auto' என்ற [txt2unicode] (தமிழ் / txt2unicode / README.md) மற்றும் [குறைபாடு] (உதாரணங்கள் / txt2unicode / encodes_chars / README.md) பற்றி மேலும் விவரங்களை படிக்க
+இப்போது, அது 25 தமிழ் குறியாக்கம் கொண்ட ஆதரிக்கிறது. 'auto2unicode' மற்றும் 'unicode2auto' என்ற [txt2unicode](tamil/txt2unicode/README.md) மற்றும் [குறைபாடு](examples/txt2unicode/encodes_chars/README.md) பற்றி மேலும் விவரங்களை படிக்க
 
 #txt2ipa
-Tamil Unicode Text to International Phonetic Alphabet (IPA) converter 
+Tamil Unicode Text to International Phonetic Alphabet (IPA) converter
 Read more details about [txt2ipa](tamil/txt2ipa/README.md)
-சர்வதேச (ஐபிஏ) மாற்றி, தமிழ் யுனிகோட் உரை; பற்றி மேலும் விவரங்களை படிக்க (தமிழ் / txt2ipa / README.md) 
+சர்வதேச (ஐபிஏ) மாற்றி, தமிழ் யுனிகோட் உரை; பற்றி மேலும் விவரங்களை படிக்க [இங்கு சொடுக்கவும்](tamil/txt2ipa/README.md).
 
 #transliterate
 the python package `transliterate` provides for commonly used transliteration
@@ -51,7 +51,7 @@ where you can supply English text, which phonetically encodes Tamil, and then re
 `transliterate` தொகுப்பு பொதுவாக பயன்படுத்தப்படும் ஒலிபெயர்ப்பு வழங்குகிறது; மூன்று வகையானவை
 1. அழகி - தமிழ் கடிதங்கள் ஒலிப்பு வரைபடங்கள் - பல -> ஒரு ஆதரவு பல வடிவம் உள்ளீடுகள்
 2. யாழ்ப்பாண நூலகம் - தமிழ் கடிதங்கள் ஒலிப்பு வரைபடங்கள் - ஒன்று> ஒரு
-3. பலதரப்பட்ட அமைப்பு - உயிர் + மெய் உச்சரிப்பு மேப்பிங் அடிப்படையில் 
+3. பலதரப்பட்ட அமைப்பு - உயிர் + மெய் உச்சரிப்பு மேப்பிங் அடிப்படையில்
 
 *C-tamil*
 the package under C-tamil provides some of the same functionality as Python 'tamil' but in ISO-C for C/C++ use.
@@ -60,7 +60,7 @@ the package under C-tamil provides some of the same functionality as Python 'tam
 
 #Onscreen Keyboard
 Open-tamil provides the keyboard layout in the file `keyboard/tamil.js` for they jQuery UI plugin.
-'tamil.js' விசைப்பலகை அமைப்பை வழங்குகிறது. 
+'tamil.js' விசைப்பலகை அமைப்பை வழங்குகிறது.
 
 #Language Models (மாதிரிகள்)
 Basic support for letter unigram, bigram models using UTF-8 based corpora are supported in the package 'ngram/'
@@ -81,15 +81,15 @@ Open-Tamil is a set of Python libraries which can help your application - web, s
 
 Open-Tamil is still a basic collection of tools - its not complete yet. We have keyboard layouts, converters to change old encoding to UTF-8, N-gram language models, transliterators etc.
 
-Examples for using Python Open-Tamil are found in https://github.com/arcturusannamalai/open-tamil/tree/master/test
+Examples for using Python Open-Tamil are found [here](tests/).
 
-உள்ளீடுகள் முதலியன டெஸ்க்டாப் வலை அமைப்பு மென்பொருள், வரைகலை ஆதரவு தமிழ் உரை செயலாக்க - ஓபன் தமிழ் பைதான் உங்கள் விண்ணப்பத்தை உதவும் தொகுப்பு. திறந்த தமிழ் இன்னும் கருவிகள் ஒரு அடிப்படை தொகுப்பு ஆகும் - அதன் இன்னமும் முடிவடையவில்லை. நாம், UTF-8, என்-கிராம் மொழி மாதிரிகள், transliterators முதலியன பழைய முறையை மாற்ற விசைப்பலகை அமைப்பு, மாற்றிகள் வேண்டும். பைதான் ஓபன் தமிழ் பயன்படுத்தி உதாரணங்கள் https://github.com/arcturusannamalai/open-tamil/tree/master/test காணப்படுகின்றன
+உள்ளீடுகள் முதலியன டெஸ்க்டாப் வலை அமைப்பு மென்பொருள், வரைகலை ஆதரவு தமிழ் உரை செயலாக்க - ஓபன் தமிழ் பைதான் உங்கள் விண்ணப்பத்தை உதவும் தொகுப்பு. திறந்த தமிழ் இன்னும் கருவிகள் ஒரு அடிப்படை தொகுப்பு ஆகும் - அதன் இன்னமும் முடிவடையவில்லை. நாம், UTF-8, என்-கிராம் மொழி மாதிரிகள், transliterators முதலியன பழைய முறையை மாற்ற விசைப்பலகை அமைப்பு, மாற்றிகள் வேண்டும். பைதான் ஓபன் தமிழ் பயன்படுத்தி உதாரணங்கள் [இங்கு](tests/) காணப்படுகின்றன.
 
 Goals
 =====
 Goal of this package is to collect and develop open-source licensed Tamil tools, in one location that provide the following,
 
-1. Unicode standard tools for Tamil - provide various tools for Tamil Unicode development. Currently 25 encodes are supported, read about it [here](tamil/txt2unicode/README.md) 
+1. Unicode standard tools for Tamil - provide various tools for Tamil Unicode development. Currently 25 encodes are supported, read about it [here](tamil/txt2unicode/README.md)
 2. Access Unicode Tamil letters, vowels and consonants.
 3. Breakdown Tamil glyphs and unicode code-points into Tamil letter representations - collation
 4. Tools for navigating a corpus of data, build word frequency, prediction tables etc.
@@ -102,7 +102,7 @@ Contributing to Open-Tamil
 ==========================
 1. Please add your code, and unit tests under MIT, GNU GPL or ASF licenses.
 2. Update your code into modules, add unit tests following the Python flake8, pylint standards
-3. Please do not mix TABS and SPACES. Use 4-space for Tabs. Use 
+3. Please do not mix TABS and SPACES. Use 4-space for Tabs.
 4. Make sure your module installed as part of pip package
 5. Ensure your code works for Python 2 and 3.
 


### PR DESCRIPTION
Changed absolute URL references to relative reference to the repository for README.txt. This fixes #111 