### PR TITLE
Migrate URL patterns to Django 4.x style and update dependencies

### DIFF
--- a/webapp/opentamilapp/urls.py
+++ b/webapp/opentamilapp/urls.py
@@ -1,69 +1,68 @@
 """opentamilweb URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+    https://docs.djangoproject.com/en/4.2/topics/http/urls/  # Updated URL
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Import the include() function: from django.urls import include, path  # Updated import
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 import sys
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.shortcuts import redirect
 
 from .views import *
 
 urlpatterns = [
-    url(r"^$", index, name="home"),
-    url(r"^apidoc/$", lambda r: redirect("/static/sphinx_doc/_build/html/index.html")),
-    url(r"^tts_demo/$", tts_demo, name="tts_demo"),
-    url(r"^translite/$", trans, name="translite"),
-    url(r"^tsci/$", uni, name="tsci"),
-    url(r"^keechu/$", keechu, name="keechu"),
-    url(r"^sandhi-check/$", sandhi_check, name="sandhi"),
-    url(r"^spell/$", spl, name="spell"),
-    url(r"^revers/$", rev, name="rever"),
-    url(r"^number/$", num, name="number"),
-    url(r"^anagram/$", anag, name="anagram"),
-    url(r"^unigram/$", unig, name="unigram"),
-    url(r"^vaypaadu/$", vaypaadu, name="multiplication"),
-    url(r"^number/(?P<num>\d+)/$", numstr, name="numstr"),
-    url(r"^tsci/(?P<tsci>.+?)/$", unicod, name="unicod"),
-    url(r"^keechu/(?P<k1>.+?)/$", keech, name="keech"),
-    url(r"^sandhi-checker/$", call_sandhi_check, name="sandhi_check"),
-    url(r"^translite/(?P<tan>.+?)/$", translite, name="phonetic"),
-    url(r"^spell/(?P<k1>.+?)/$", spell_check, name="spell_check"),
-    url(r"^aspell/$", aspell_spell_check, name="aspell_spell_check"),
-    url(r"^aspell_spellchecker", aspell_spellchecker, name="aspell_spellchecker"),
-    url(r"^tamilinayavaani/$", tamilinayavaani_spell_check, name="tamilinayavaani_spell_check"),
-    url(r"^tamilinayavaani_spellchecker", tamilinayavaani_spellchecker, name="tamilinayavaani_spellchecker"),
-    url(r"^ngram/$", ngra, name="ta_ngram"),
-    url(r"^ngram/(?P<ng>.+?)/$", test_ngram, name="ngram"),
-    url(r"^anagram/(?P<word>.+?)/$", anagram, name="ta_anagram"),
-    url(r"^unigram/(?P<word>.+?)/$", test_basic, name="ta_unigram"),
-    url(r"^revers/(?P<word>.+?)/$", revers, name="ta_revers"),
-    url(r"^xword/$", xword, name="ta_xword"),
-    url(r"^summarizer/", summarizer, name="ta_summarizer"),
-    url(r"^morse/(?P<direction>.+)/(?P<word>.+)/$", morse, name="ta_morse"),
-    url(r"^morse/$", morse_code, name="morse_code"),
-    url(r"^minnal/$", minnal, name="ta_minnal"),
-    url(r"^minnal/(?P<word>.+?)/$", test_minnal, name="minnal"),
-    url(
-        r"^textrandomizer_auth/(?P<key>.+)/$", textrandomizer, name="ta_textrandomizer"
-    ),
-    url(r"^textrandomizer/(?P<level>.+)/$", test_textrandomizer, name="textrandomizer"),
-    url(r"^stemmer/$", tastemmer, name="stemmer"),
-    url(r"^stemmer/json/$", lambda x: tastemmer(x, use_json=True), name="json_stemmer"),
-    url(r"version/", version, name="version"),
-    url(r"matthirai/", matthirai, name="matthirai"),
-    url(r"matthirai/json/$", lambda x: matthirai(x, use_json=True), name="json_matthirai"),
-    url(r"kanippaan/", kanippaan, name="kanippaan"),
-    url(r"kanippaan/json/$", lambda x: kanippaan(x, use_json=True), name="json_kanippaan"),
-    url(r"^classify-word/$", classify_word, name="classify_word"),
-    url(r"^get-classify/$", get_classify, name="classifier")]
+    path('', index, name='home'),
+    path('apidoc/', lambda r: redirect('/static/sphinx_doc/_build/html/index.html')),
+    path('tts_demo/', tts_demo, name='tts_demo'),
+    path('translite/', trans, name='translite'),
+    path('tsci/', uni, name='tsci'),
+    path('keechu/', keechu, name='keechu'),
+    path('sandhi-check/', sandhi_check, name='sandhi'),
+    path('spell/', spl, name='spell'),
+    path('revers/', rev, name='rever'),
+    path('number/', num, name='number'),
+    path('anagram/', anag, name='anagram'),
+    path('unigram/', unig, name='unigram'),
+    path('vaypaadu/', vaypaadu, name='multiplication'),
+    re_path(r'^number/(?P<num>\d+)/$', numstr, name='numstr'),
+    re_path(r'^tsci/(?P<tsci>.+?)/$', unicod, name='unicod'),
+    re_path(r'^keechu/(?P<k1>.+?)/$', keech, name='keech'),
+    path('sandhi-checker/', call_sandhi_check, name='sandhi_check'),
+    re_path(r'^translite/(?P<tan>.+?)/$', translite, name='phonetic'),
+    re_path(r'^spell/(?P<k1>.+?)/$', spell_check, name='spell_check'),
+    path('aspell/', aspell_spell_check, name='aspell_spell_check'),
+    path('aspell_spellchecker', aspell_spellchecker, name='aspell_spellchecker'),
+    path('tamilinayavaani/', tamilinayavaani_spell_check, name='tamilinayavaani_spell_check'),
+    path('tamilinayavaani_spellchecker', tamilinayavaani_spellchecker, name='tamilinayavaani_spellchecker'),
+    path('ngram/', ngra, name='ta_ngram'),
+    re_path(r'^ngram/(?P<ng>.+?)/$', test_ngram, name='ngram'),
+    re_path(r'^anagram/(?P<word>.+?)/$', anagram, name='ta_anagram'),
+    re_path(r'^unigram/(?P<word>.+?)/$', test_basic, name='ta_unigram'),
+    re_path(r'^revers/(?P<word>.+?)/$', revers, name='ta_revers'),
+    path('xword/', xword, name='ta_xword'),
+    path('summarizer/', summarizer, name='ta_summarizer'),
+    re_path(r'^morse/(?P<direction>.+)/(?P<word>.+)/$', morse, name='ta_morse'),
+    path('morse/', morse_code, name='morse_code'),
+    path('minnal/', minnal, name='ta_minnal'),
+    re_path(r'^minnal/(?P<word>.+?)/$', test_minnal, name='minnal'),
+    re_path(r'^textrandomizer_auth/(?P<key>.+)/$', textrandomizer, name='ta_textrandomizer'),
+    re_path(r'^textrandomizer/(?P<level>.+)/$', test_textrandomizer, name='textrandomizer'),
+    path('stemmer/', tastemmer, name='stemmer'),
+    path('stemmer/json/', lambda x: tastemmer(x, use_json=True), name='json_stemmer'),
+    path('version/', version, name='version'),
+    path('matthirai/', matthirai, name='matthirai'),
+    path('matthirai/json/', lambda x: matthirai(x, use_json=True), name='json_matthirai'),
+    path('kanippaan/', kanippaan, name='kanippaan'),
+    path('kanippaan/json/', lambda x: kanippaan(x, use_json=True), name='json_kanippaan'),
+    path('classify-word/', classify_word, name='classify_word'),
+    path('get-classify/', get_classify, name='classifier'),
+]

--- a/webapp/opentamilweb/settings.py
+++ b/webapp/opentamilweb/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 """
 
 import os
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/webapp/opentamilweb/urls.py
+++ b/webapp/opentamilweb/urls.py
@@ -14,10 +14,10 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 import sys
-from django.conf.urls import url, include
+from django.urls import path, include
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 if sys.version.find("2.6") >= 0:
     urlpatterns = [
@@ -25,9 +25,9 @@ if sys.version.find("2.6") >= 0:
     ]
 else:
     urlpatterns = [
-        url(r"^i18n/", include("django.conf.urls.i18n")),
+        path('i18n/', include('django.conf.urls.i18n')),
     ]
     urlpatterns += i18n_patterns(
-        # url(r'^admin/', admin.site.urls),
-        url(_(r""), include("opentamilapp.urls")),
+        # path('admin/', admin.site.urls),
+        path('', include('opentamilapp.urls')),
     )

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,2 +1,3 @@
 django==4.2.16
 open-tamil>=0.9
+tamilinayavaani>=0.13


### PR DESCRIPTION
This PR updates the URL patterns in `webapp/opentamilapp/urls.py` and `webapp/opentamilweb/urls.py` to be compatible with Django 4.x.  The old `url()` syntax has been replaced with `path()` and `re_path()` as appropriate.  This change is necessary to ensure compatibility with newer Django versions.

Key Changes:

* Replaced `url(r'^...$')` with `path('...')`.
* Replaced `url(r'^...(?P<...>.+?)/$')` with `re_path(r'^...(?P<...>.+?)/$')` for patterns with named capture groups.
* Updated imports from `django.conf.urls` to `django.urls`.
* Updated the main project's `urls.py` to use `path` and include the app's urls.
* Updated `settings.py` to use `gettext_lazy` instead of `ugettext_lazy` for translation.

Additionally, this PR updates the `requirements.txt` file to include the `tamilinayavaani` package. This package is required for the Tamil Inayavaani spell checker functionality.

Testing:

* Manually tested the URL routes in the development environment to ensure they are working as expected.