### PR TITLE
Fix: Resolves "string index out of range" error in Tamil N-gram page

### DIFF
--- a/webapp/opentamilapp/views.py
+++ b/webapp/opentamilapp/views.py
@@ -280,10 +280,9 @@ def spell_check(request, k1):
 def test_ngram(request, ng):
     obj = DTrie()
     prev_letter = ""
-    # per-line processor - remove spaces
     for char in get_letters("".join(re.split("\s+", ng)).lower()):
         if (prev_letter.isalpha() and char.isalpha()) or (
-                utf8.is_tamil_unicode(prev_letter) and utf8.is_tamil_unicode(char)
+                prev_letter and utf8.is_tamil_unicode(prev_letter) and utf8.is_tamil_unicode(char)
         ):
             bigram = "".join([prev_letter, char])
             obj.add(bigram)  # update previous


### PR DESCRIPTION
This commit addresses the "string index out of range" error encountered in the Tamil N-gram page (webapp/opentamilapp/views.py, line 288).  The error occurred within the `utf8.is_tamil_unicode` function when processing bigrams.

**Problem:**

The original code iterated through characters in an input string `ng` (intended to be a bigram), but the loop logic and conditional checks could potentially lead to the `is_tamil_unicode` function being called with an empty string or a string of length zero.  Specifically, the issue arose because the `is_tamil_unicode_predicate` function attempts to access the first element (`x[0]`) of the input sequence `x` *without* checking if the sequence is empty.  This would cause an `IndexError: string index out of range` when an empty string is passed.

**Solution:**

The fix ensures that the `is_tamil_unicode` function is called only when `prev_letter` is not an empty string.  This prevents the `is_tamil_unicode_predicate` function from attempting to access an index on an empty string, thereby resolving the `IndexError`.

**Details of the fix:**

The conditional check on line 286 has been modified to:
```python
if (prev_letter.isalpha() and char.isalpha()) or (prev_letter and utf8.is_tamil_unicode(prev_letter) and utf8.is_tamil_unicode(char)):